### PR TITLE
Support environment variables for enabled

### DIFF
--- a/kedro_neptune/config.py
+++ b/kedro_neptune/config.py
@@ -48,7 +48,7 @@ def get_neptune_config() -> NeptuneConfig:
     project = _parse_config_input(config['neptune']['project'])
     base_namespace = config['neptune']['base_namespace']
     source_files = config['neptune']['upload_source_files']
-    enabled = config['neptune'].get('enabled', True)
+    enabled = bool(_parse_config_input(config['neptune']))
 
     return NeptuneConfig(
         api_token=api_token,

--- a/kedro_neptune/config.py
+++ b/kedro_neptune/config.py
@@ -48,7 +48,7 @@ def get_neptune_config() -> NeptuneConfig:
     project = _parse_config_input(config['neptune']['project'])
     base_namespace = config['neptune']['base_namespace']
     source_files = config['neptune']['upload_source_files']
-    enabled = bool(_parse_config_input(config['neptune']))
+    enabled = bool(_parse_config_input(config['neptune'].get('enabled', True)))
 
     return NeptuneConfig(
         api_token=api_token,


### PR DESCRIPTION
In the example, config file contains enabled setting given with an environmental variable. It is very useful to control neptune with an env variable yet currently it is not possible.

neptune:
  #GLOBAL CONFIG
  project: $NEPTUNE_PROJECT
  base_namespace: kedro
  enabled: $NEPTUNE_ENABLED