### PR TITLE
 Use NEPTUNE_CUSTOM_RUN_ID env var for distributed async workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.5.0
 
 ### Features
-- Added support for the `NEPTUNE_CUSTOM_RUN_ID` environment variable ([#81](https://github.com/neptune-ai/kedro-neptune/pull/81) by @turn1a)
+- Added support for the `NEPTUNE_CUSTOM_RUN_ID` environment variable ([#81](https://github.com/neptune-ai/kedro-neptune/pull/81))
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0
+
+### Features
+- Added support for the `NEPTUNE_CUSTOM_RUN_ID` environment variable ([#81](https://github.com/neptune-ai/kedro-neptune/pull/81) by @turn1a)
+
 ## 0.4.0
 
 ### Features

--- a/src/kedro_neptune/__init__.py
+++ b/src/kedro_neptune/__init__.py
@@ -434,11 +434,14 @@ class NeptuneHooks:
 
     @hook_impl
     def after_catalog_created(self, catalog: DataCatalog) -> None:
-        self._run_id = hashlib.md5(str(time.time()).encode()).hexdigest()
+        self._run_id = (
+            os.environ.get("NEPTUNE_CUSTOM_RUN_ID")
+            or hashlib.md5(str(time.time()).encode()).hexdigest()
+        )
 
         config = get_neptune_config(settings)
 
-        if config.enabled:
+        if config.enabled and not os.environ.get("NEPTUNE_CUSTOM_RUN_ID"):
             os.environ["NEPTUNE_CUSTOM_RUN_ID"] = self._run_id
 
         catalog.add(dataset_name="neptune_run", dataset=NeptuneRunDataset())

--- a/tests/kedro_neptune/test_standard.py
+++ b/tests/kedro_neptune/test_standard.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from datetime import datetime
+
 from tests.kedro_neptune.utils.kedro_utils import run_pipeline
 from tests.kedro_neptune.utils.run_utils import assert_structure
 
@@ -25,3 +27,12 @@ def test_run():
 def test_run_with_params():
     run_pipeline(project="planets", session_params={"extra_params": {"travel_speed": 40000}})
     assert_structure(travel_speed=40000)
+
+
+def test_run_with_custom_run_id():
+    custom_run_id = str(datetime.now())
+    run_pipeline(
+        project="planets",
+        custom_run_id=custom_run_id,
+    )
+    assert_structure(custom_run_id=custom_run_id)

--- a/tests/kedro_neptune/utils/kedro_utils.py
+++ b/tests/kedro_neptune/utils/kedro_utils.py
@@ -15,6 +15,7 @@
 #
 __all__ = ["run_pipeline"]
 
+import os
 from pathlib import Path
 from typing import (
     Any,
@@ -26,12 +27,21 @@ from kedro.framework.session import KedroSession
 from kedro.framework.startup import bootstrap_project
 
 
-def run_pipeline(project: str, run_params: Dict[str, Any] = None, session_params: Dict[str, Any] = None):
+def run_pipeline(
+    project: str,
+    run_params: Dict[str, Any] = None,
+    session_params: Dict[str, Any] = None,
+    custom_run_id: str = None,
+):
     if run_params is None:
         run_params = {}
 
     if session_params is None:
         session_params = {}
+
+    if custom_run_id:
+        os.environ["NEPTUNE_CUSTOM_RUN_ID"] = custom_run_id
+
     configure_project(project)
 
     bootstrap_project(Path(".").resolve())


### PR DESCRIPTION
## Summary

This PR modifies the Neptune run ID used by the plugin to make use of the `NEPTUNE_CUSTOM_RUN_ID` environmental variable if it is already available.

## Motivation

Currently, the plugin cannot be used in a distributed asynchronous workflow (such as Kubeflow, AWS Batch, etc.), where multiple containers run independently. Each container creates a new run ID in Neptune to log into during the `after_catalog_created()` execution in `NeptuneHooks`. By setting `NEPTUNE_CUSTOM_RUN_ID` to the same value for each container before the `kedro run` execution and utilizing this existing environmental variable, we enable the possibility for many nodes executed asynchronously to log into the same Neptune run.

## Changes

This update sets the `_run_id` during the `after_catalog_created()` execution in `NeptuneHooks` to the value of the `NEPTUNE_CUSTOM_RUN_ID` environmental variable if it exists before the hook execution.

## Testing

TBD

## Notes

Are there any additional considerations for ensuring proper logging in such a workflow? I assume there might be some issues related to total runtime. I'm willing to add any missing details.