### PR TITLE
Get Neptune configuration from selected kedro environment

### DIFF
--- a/src/kedro_neptune/config.py
+++ b/src/kedro_neptune/config.py
@@ -18,6 +18,7 @@ from typing import List
 
 from kedro_neptune.utils import (
     ensure_bool,
+    get_kedro_env,
     parse_config_value,
 )
 
@@ -33,7 +34,9 @@ class NeptuneConfig:
 
 
 def get_neptune_config(settings) -> NeptuneConfig:
-    config_loader = settings.CONFIG_LOADER_CLASS(settings.CONF_SOURCE, **settings.CONFIG_LOADER_ARGS)
+    config_loader = settings.CONFIG_LOADER_CLASS(
+        settings.CONF_SOURCE, env=get_kedro_env(), **settings.CONFIG_LOADER_ARGS
+    )
     credentials = config_loader["credentials_neptune"]
     config = config_loader["neptune"]
 

--- a/src/kedro_neptune/config.py
+++ b/src/kedro_neptune/config.py
@@ -35,7 +35,7 @@ class NeptuneConfig:
 
 def get_neptune_config(settings) -> NeptuneConfig:
     config_loader = settings.CONFIG_LOADER_CLASS(
-        settings.CONF_SOURCE, env=get_kedro_env(), **settings.CONFIG_LOADER_ARGS
+        settings.CONF_SOURCE, env=get_kedro_env(settings), **settings.CONFIG_LOADER_ARGS
     )
     credentials = config_loader["credentials_neptune"]
     config = config_loader["neptune"]

--- a/src/kedro_neptune/utils.py
+++ b/src/kedro_neptune/utils.py
@@ -45,14 +45,22 @@ def ensure_bool(value: Optional[Union[str, bool]]) -> bool:
     return value
 
 
-def get_kedro_env() -> Optional[str]:
+def get_kedro_env(settings: object) -> Optional[str]:
     """Returns kedro configuration environment to use.
 
+    Args:
+        settings (object): Kedro settings.
+
     Returns:
-        Optional[str]: `--env` commandline argument's value (if present)
-            or `KEDRO_ENV` value.
+        Optional[str]: `--env` commandline argument's value,
+            `$KEDRO_ENV` value, `settings.CONFIG_LOADER_ARGS["default_run_env"]`
+            or `settings.CONFIG_LOADER_ARGS["base_env"]`.
     """
     for i, arg in enumerate(sys.argv):
         if arg == "--env" and i + 1 < len(sys.argv):
             return sys.argv[i + 1]
-    return os.getenv("KEDRO_ENV")
+    return (
+        os.getenv("KEDRO_ENV")
+        or settings.CONFIG_LOADER_ARGS.get("default_run_env")
+        or settings.CONFIG_LOADER_ARGS.get("base_env")
+    )

--- a/src/kedro_neptune/utils.py
+++ b/src/kedro_neptune/utils.py
@@ -16,9 +16,11 @@
 __all__ = [
     "ensure_bool",
     "parse_config_value",
+    "get_kedro_env",
 ]
 
 import os
+import sys
 from typing import (
     Any,
     Optional,
@@ -41,3 +43,16 @@ def ensure_bool(value: Optional[Union[str, bool]]) -> bool:
         return value.lower().strip() not in ("false", "no", "0")
 
     return value
+
+
+def get_kedro_env() -> Optional[str]:
+    """Returns kedro configuration environment to use.
+
+    Returns:
+        Optional[str]: `--env` commandline argument's value (if present)
+            or `KEDRO_ENV` value.
+    """
+    for i, arg in enumerate(sys.argv):
+        if arg == "--env" and i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+    return os.getenv("KEDRO_ENV")

--- a/tests/kedro_neptune/test_utils.py
+++ b/tests/kedro_neptune/test_utils.py
@@ -16,7 +16,10 @@
 from unittest import mock
 from unittest.mock import patch
 
-from kedro_neptune.utils import ensure_bool, get_kedro_env
+from kedro_neptune.utils import (
+    ensure_bool,
+    get_kedro_env,
+)
 
 
 class TestUtils:
@@ -40,44 +43,40 @@ class TestUtils:
 
 
 class TestGetKedroEnv:
+    def _test_get_kedro_env(self, config_loader_args: dict, expected: str) -> None:
+        settings = mock.Mock()
+        settings.CONFIG_LOADER_ARGS = config_loader_args
+        assert get_kedro_env(settings) == expected
+
     def test_env_from_commandline(self):
         """Test that the function returns the value of the `--env` commandline argument."""
         with patch("sys.argv", ["kedro", "run", "--env", "test"]):
-            settings = mock.Mock()
-            settings.CONFIG_LOADER_ARGS = {}
-            expected = "test"
-            result = get_kedro_env(settings)
-            assert result == expected
+            self._test_get_kedro_env(config_loader_args={}, expected="test")
 
     def test_env_from_environment_variable(self):
         """Test that the function returns the value of the `$KEDRO_ENV` environment variable."""
         with patch("os.environ", {"KEDRO_ENV": "test"}):
-            settings = mock.Mock()
-            settings.CONFIG_LOADER_ARGS = {}
-            expected = "test"
-            result = get_kedro_env(settings)
-            assert result == expected
+            self._test_get_kedro_env(config_loader_args={}, expected="test")
 
     def test_env_from_default_run_env(self):
         """Test that the function returns the value of `settings.CONFIG_LOADER_ARGS["default_run_env"]`."""
-        settings = mock.Mock()
-        settings.CONFIG_LOADER_ARGS = {"default_run_env": "test"}
-        expected = "test"
-        result = get_kedro_env(settings)
-        assert result == expected
+        self._test_get_kedro_env(config_loader_args={"default_run_env": "test"}, expected="test")
 
     def test_env_from_base_env(self):
         """Test that the function returns the value of `settings.CONFIG_LOADER_ARGS["base_env"]`."""
-        settings = mock.Mock()
-        settings.CONFIG_LOADER_ARGS = {"base_env": "test"}
-        expected = "test"
-        result = get_kedro_env(settings)
-        assert result == expected
+        self._test_get_kedro_env(config_loader_args={"base_env": "test"}, expected="test")
 
     def test_env_none(self):
         """Test that the function returns `None` when none of the above conditions are met."""
-        settings = mock.Mock()
-        settings.CONFIG_LOADER_ARGS = {}
-        expected = None
-        result = get_kedro_env(settings)
-        assert result == expected
+        self._test_get_kedro_env(config_loader_args={}, expected=None)
+
+    def test_order_of_precedence(self):
+        """Test that the environment is read from `sys.argv`, `$KEDRO_ENV`,
+        `settings.CONFIG_LOADER_ARGS["default_run_env"]` or `settings.CONFIG_LOADER_ARGS["base_env"]`,
+        in order of precedence"""
+
+        with patch("sys.argv", ["kedro", "run", "--env", "argv"]), patch("os.environ", {"KEDRO_ENV": "env"}):
+            self._test_get_kedro_env(
+                config_loader_args={"default_run_env": "default", "base_env": "base"},
+                expected="argv",
+            )

--- a/tests/kedro_neptune/test_utils.py
+++ b/tests/kedro_neptune/test_utils.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from kedro_neptune.utils import ensure_bool
+from unittest import mock
+from unittest.mock import patch
+
+from kedro_neptune.utils import ensure_bool, get_kedro_env
 
 
 class TestUtils:
@@ -34,3 +37,47 @@ class TestUtils:
         assert ensure_bool(value=" True  ") is True
         assert ensure_bool(value="True") is True
         assert ensure_bool(value="true") is True
+
+
+class TestGetKedroEnv:
+    def test_env_from_commandline(self):
+        """Test that the function returns the value of the `--env` commandline argument."""
+        with patch("sys.argv", ["kedro", "run", "--env", "test"]):
+            settings = mock.Mock()
+            settings.CONFIG_LOADER_ARGS = {}
+            expected = "test"
+            result = get_kedro_env(settings)
+            assert result == expected
+
+    def test_env_from_environment_variable(self):
+        """Test that the function returns the value of the `$KEDRO_ENV` environment variable."""
+        with patch("os.environ", {"KEDRO_ENV": "test"}):
+            settings = mock.Mock()
+            settings.CONFIG_LOADER_ARGS = {}
+            expected = "test"
+            result = get_kedro_env(settings)
+            assert result == expected
+
+    def test_env_from_default_run_env(self):
+        """Test that the function returns the value of `settings.CONFIG_LOADER_ARGS["default_run_env"]`."""
+        settings = mock.Mock()
+        settings.CONFIG_LOADER_ARGS = {"default_run_env": "test"}
+        expected = "test"
+        result = get_kedro_env(settings)
+        assert result == expected
+
+    def test_env_from_base_env(self):
+        """Test that the function returns the value of `settings.CONFIG_LOADER_ARGS["base_env"]`."""
+        settings = mock.Mock()
+        settings.CONFIG_LOADER_ARGS = {"base_env": "test"}
+        expected = "test"
+        result = get_kedro_env(settings)
+        assert result == expected
+
+    def test_env_none(self):
+        """Test that the function returns `None` when none of the above conditions are met."""
+        settings = mock.Mock()
+        settings.CONFIG_LOADER_ARGS = {}
+        expected = None
+        result = get_kedro_env(settings)
+        assert result == expected


### PR DESCRIPTION
## Summary

This PR allows to use Kedro environments to specify different Neptune configs for different environments.

## Motivation

Currently, the Neptune configuration and credentials can only be read from `base` (or `local` or `default_run_env` setting of `CONFIG_LOADER_ARGS` in `settings.py`). Kedro allows the creation of various environments within the configuration directory to manage different environments (like dev, test and prod). This changeset makes it possible to use these environments to specify different Neptune settings for different kedro environments.

## Changes

Read kedro environment from `sys.argv`, `$KEDRO_ENV`, `settings.CONFIG_LOADER_ARGS["default_run_env"]` or `settings.CONFIG_LOADER_ARGS["base_env"]` (in this order, as per kedro documentation) and pass it to config loader init in `get_neptune_config()`.

## Testing

Tested by running `kedro run --env <env-name>`, `KEDRO_ENV=<env-name> kedro run` and without setting the kedro environment at all.